### PR TITLE
add aarch64, fix build format, chmod bad bin in appimage

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.bug.yml
+++ b/.github/ISSUE_TEMPLATE/issue.bug.yml
@@ -52,6 +52,7 @@ body:
       label: CPU architecture
       options:
         - x86-64
+        - arm64
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -111,7 +111,7 @@ jobs:
             exit 0
           else
             assets=$(curl -u "${{ secrets.CR_USER }}:${{ secrets.CR_PAT }}" -sX GET "https://api.github.com/repos/OrcaSlicer/OrcaSlicer/releases/tags/${EXT_RELEASE}" | jq -r '.assets[].browser_download_url')
-            if grep -q "OrcaSlicer_Linux_AppImage_Ubuntu2404" <<< "${assets}"; then
+            if grep -q "OrcaSlicer_Linux_AppImage_Ubuntu2404_aarch64" <<< "${assets}"; then
               artifacts_found="true"
             else
               artifacts_found="false"

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-selkies:debiantrixie
+FROM ghcr.io/linuxserver/baseimage-selkies:arm64v8-debiantrixie
 
 # set version label
 ARG BUILD_DATE
@@ -57,7 +57,7 @@ RUN \
     | awk '/tag_name/{print $4;exit}' FS='[""]'); \
   fi && \
   RELEASE_URL=$(curl -sX GET "https://api.github.com/repos/OrcaSlicer/OrcaSlicer/releases/latest"     | awk '/url/{print $4;exit}' FS='[""]') && \
-  DOWNLOAD_URL=$(curl -sX GET "${RELEASE_URL}" | awk '/browser_download_url.*Ubuntu2404_V/{print $4;exit}' FS='[""]') && \
+  DOWNLOAD_URL=$(curl -sX GET "${RELEASE_URL}" | awk '/browser_download_url.*Ubuntu2404_aarch64/{print $4;exit}' FS='[""]') && \
   cd /tmp && \
   curl -o \
     /tmp/orca.app -L \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     DEV_DOCKERHUB_IMAGE = 'lsiodev/orcaslicer'
     PR_DOCKERHUB_IMAGE = 'lspipepr/orcaslicer'
     DIST_IMAGE = 'ubuntu'
-    MULTIARCH = 'false'
+    MULTIARCH = 'true'
     CI = 'true'
     CI_WEB = 'true'
     CI_PORT = '3001'

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The architectures supported by this image are:
 | Architecture | Available | Tag |
 | :----: | :----: | ---- |
 | x86-64 | ✅ | amd64-\<version tag\> |
-| arm64 | ❌ | |
+| arm64 | ✅ | arm64v8-\<version tag\> |
 
 ## Application Setup
 
@@ -643,6 +643,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **20.06.26:** - Add aarch64 platform.
 * **11.05.26:** - Rebase to Debian Trixie.
 * **19.04.26:** - Rebase to resolute.
 * **29.03.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -8,7 +8,7 @@ release_tag: latest
 ls_branch: master
 external_artifact_check: |
   assets=$(curl -u "${{ '{{' }} secrets.CR_USER {{ '}}' }}:${{ '{{' }} secrets.CR_PAT {{ '}}' }}" -sX GET "https://api.github.com/repos/OrcaSlicer/OrcaSlicer/releases/tags/${EXT_RELEASE}" | jq -r '.assets[].browser_download_url')
-  if grep -q "OrcaSlicer_Linux_AppImage_Ubuntu2404" <<< "${assets}"; then
+  if grep -q "OrcaSlicer_Linux_AppImage_Ubuntu2404_aarch64" <<< "${assets}"; then
     artifacts_found="true"
   else
     artifacts_found="false"
@@ -24,7 +24,7 @@ repo_vars:
   - DEV_DOCKERHUB_IMAGE = 'lsiodev/orcaslicer'
   - PR_DOCKERHUB_IMAGE = 'lspipepr/orcaslicer'
   - DIST_IMAGE = 'ubuntu'
-  - MULTIARCH = 'false'
+  - MULTIARCH = 'true'
   - CI = 'true'
   - CI_WEB = 'true'
   - CI_PORT = '3001'

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -11,6 +11,7 @@ project_blurb_optional_extras_enabled: false
 # supported architectures
 available_architectures:
   - {arch: "{{ arch_x86_64 }}", tag: "latest"}
+  - {arch: "{{ arch_arm64 }}", tag: "arm64v8-latest"}
 # development version
 development_versions: false
 # container parameters
@@ -106,6 +107,7 @@ init_diagram: |
   "orcaslicer:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "20.06.26:", desc: "Add aarch64 platform."}
   - {date: "11.05.26:", desc: "Rebase to Debian Trixie."}
   - {date: "19.04.26:", desc: "Rebase to resolute."}
   - {date: "29.03.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}


### PR DESCRIPTION
Add aarch64 support, change artifact check to look for aarch64 appimage, update build logic, and add chmod. 

Native test on build node: 

<img width="1394" height="846" alt="orca-arm" src="https://github.com/user-attachments/assets/fe3f0451-9398-41fb-801d-3ec46ca47bbb" />
